### PR TITLE
Use specific pex file. Upgrade to 0.10.3

### DIFF
--- a/docker/amd64-Dockerfile
+++ b/docker/amd64-Dockerfile
@@ -8,7 +8,7 @@ RUN apk update && apk add \
 #no need to add cleaning command as alpine cleans package automatically
 
 #download kolibri
-RUN curl -o kolibri -L https://learningequality.org/r/kolibri-pex-latest
+RUN curl -o kolibri -L https://github.com/learningequality/kolibri/releases/download/v0.10.3/kolibri-0.10.3.pex
 
 #make executable
 RUN chmod +x kolibri

--- a/docker/arm-Dockerfile
+++ b/docker/arm-Dockerfile
@@ -8,7 +8,7 @@ RUN apk update && apk add \
 #no need to add cleaning command as alpine cleans package automatically
 
 #download kolibri
-RUN curl -o kolibri -L https://learningequality.org/r/kolibri-pex-latest
+RUN curl -o kolibri -L https://github.com/learningequality/kolibri/releases/download/v0.10.3/kolibri-0.10.3.pex
 
 #make executable
 RUN chmod +x kolibri

--- a/docker/arm64-Dockerfile
+++ b/docker/arm64-Dockerfile
@@ -8,7 +8,7 @@ RUN apk update && apk add \
 #no need to add cleaning command as alpine cleans package automatically
 
 #download kolibri
-RUN curl -o kolibri -L https://learningequality.org/r/kolibri-pex-latest
+RUN curl -o kolibri -L https://github.com/learningequality/kolibri/releases/download/v0.10.3/kolibri-0.10.3.pex
 
 #make executable
 RUN chmod +x kolibri


### PR DESCRIPTION
Solves #9 

To test:

```
treehouses/kolibri-tags:amd64-use-specific-version-of-pex-eea70230
treehouses/kolibri-tags:arm64-use-specific-version-of-pex-eea70230
treehouses/kolibri-tags:arm-use-specific-version-of-pex-eea70230
```