### PR TITLE
Fix python install for recent alpine releases

### DIFF
--- a/docker/amd64-Dockerfile
+++ b/docker/amd64-Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 #install python
 RUN apk update && apk add \
-    python \
+    python2 \
     curl
 
 #no need to add cleaning command as alpine cleans package automatically

--- a/docker/arm-Dockerfile
+++ b/docker/arm-Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/alpine
+FROM multiarch/alpine:armhf-latest-stable
 
 #install python
 RUN apk update && apk add \

--- a/docker/arm-Dockerfile
+++ b/docker/arm-Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/alpine
+FROM arm32v7/alpine:3.12
 
 #install python
 RUN apk update && apk add \

--- a/docker/arm-Dockerfile
+++ b/docker/arm-Dockerfile
@@ -1,4 +1,4 @@
-FROM multiarch/alpine:armhf-latest-stable
+FROM arm32v7/alpine
 
 #install python
 RUN apk update && apk add \

--- a/docker/arm-Dockerfile
+++ b/docker/arm-Dockerfile
@@ -2,7 +2,7 @@ FROM multiarch/alpine:armhf-latest-stable
 
 #install python
 RUN apk update && apk add \
-    python \
+    python2 \
     curl
 
 #no need to add cleaning command as alpine cleans package automatically

--- a/docker/arm-Dockerfile
+++ b/docker/arm-Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM multiarch/alpine:armhf-latest-stable
 
 #install python
 RUN apk update && apk add \

--- a/docker/arm-Dockerfile
+++ b/docker/arm-Dockerfile
@@ -1,4 +1,4 @@
-FROM multiarch/alpine:armhf-latest-stable
+FROM alpine:latest
 
 #install python
 RUN apk update && apk add \

--- a/docker/arm64-Dockerfile
+++ b/docker/arm64-Dockerfile
@@ -1,4 +1,4 @@
-FROM multiarch/alpine:aarch64-latest-stable
+FROM arm64v8/alpine:3.12
 
 #install python
 RUN apk update && apk add \

--- a/docker/arm64-Dockerfile
+++ b/docker/arm64-Dockerfile
@@ -2,7 +2,7 @@ FROM multiarch/alpine:aarch64-latest-stable
 
 #install python
 RUN apk update && apk add \
-    python \
+    python2 \
     curl
 
 #no need to add cleaning command as alpine cleans package automatically


### PR DESCRIPTION
In recent alpine releases python version 2 must be specified as python2. If it is left as "python" as in the current Dockerfiles, then the following is the result:

Sending build context to Docker daemon  5.632kB
Step 1/7 : FROM multiarch/alpine:armhf-latest-stable
 ---> 1cf743ebe78e
Step 2/7 : RUN apk update && apk add python curl
 ---> Running in f53078db8735
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/armhf/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/armhf/APKINDEX.tar.gz
v3.12.1-47-g77e786238c [http://dl-cdn.alpinelinux.org/alpine/v3.12/main]
v3.12.1-51-g991a1b26b6 [http://dl-cdn.alpinelinux.org/alpine/v3.12/community]
OK: 11229 distinct packages available
ERROR: unsatisfiable constraints:
  python (missing):
    required by: world[python]
The command '/bin/sh -c apk update && apk add python curl' returned a non-zero code: 1